### PR TITLE
#8: now log the log file path

### DIFF
--- a/src/hibayes/load/extractors.py
+++ b/src/hibayes/load/extractors.py
@@ -29,6 +29,9 @@ class BaseMetadataExtractor(MetadataExtractor):
         model_name = eval_log.eval.model
         model_name = model_name.split("/")[-1] if "/" in model_name else model_name
 
+        # record the log file path this sample came from
+        log_path = eval_log.location
+
         return {
             "score": self._normalise_score(next(iter(sample.scores.values())).value),
             "target": str(sample.target),
@@ -37,6 +40,7 @@ class BaseMetadataExtractor(MetadataExtractor):
             "task": str(sample.id),
             "epoch": sample.epoch,
             "num_messages": len(sample.messages),
+            "log_path": log_path,
         }
 
     def _normalise_score(self, score: Any) -> float:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
row wise data does not have a file path record of the log file it came from.
### What is the new behavior?
This is now extracted by default from the basemeta extractor
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
you can create your custom extractors to extract more information from the log name e.g. 

```
class Finetuned(MetadataExtractor):
    """finetuned?"""

    def extract(self, sample: EvalSample, eval_log: EvalLog) -> Dict[str, Any]:
        is_finetuned = 'ft' in eval_log.location
        return {"finetuned": is_finetuned}
```