### PR TITLE
avoiding double mapping, keeping all in the config.

### DIFF
--- a/examples/cybench/dvc.lock
+++ b/examples/cybench/dvc.lock
@@ -19,9 +19,9 @@ stages:
     deps:
     - path: ../../src/hibayes/
       hash: md5
-      md5: 33a0d116c39f00631368eff9b2616609.dir
-      size: 390383
-      nfiles: 83
+      md5: b00737fccccd80f7c7084ff41b3811a7.dir
+      size: 392380
+      nfiles: 84
     - path: .output/load/data.csv
       hash: md5
       md5: 3eedd8e665e58e92bb14f82ec6439692
@@ -46,16 +46,18 @@ stages:
               mapping_name:
                 Success Count: n_correct
                 Total Attempts: n_total
+                Sample ID: task
             ModelBinomial:
               mapping_name:
                 Success Count: n_correct
                 Total Attempts: n_total
+                Sample ID: task
         platform:
     outs:
     - path: .output/model/
       hash: md5
-      md5: b31f48ed4f997b1871c096e3f6e72c1b.dir
-      size: 18294176
+      md5: 7f2ccc7d0b30f3ab1875553f8b925ca2.dir
+      size: 18294838
       nfiles: 23
   communicate:
     cmd: hibayes-comm --config files/config.yaml --analysis_state .output/model/ --out
@@ -63,13 +65,13 @@ stages:
     deps:
     - path: ../../src/hibayes/
       hash: md5
-      md5: 33a0d116c39f00631368eff9b2616609.dir
-      size: 390383
-      nfiles: 83
+      md5: b00737fccccd80f7c7084ff41b3811a7.dir
+      size: 392380
+      nfiles: 84
     - path: .output/model/
       hash: md5
-      md5: b31f48ed4f997b1871c096e3f6e72c1b.dir
-      size: 18294176
+      md5: 7f2ccc7d0b30f3ab1875553f8b925ca2.dir
+      size: 18294838
       nfiles: 23
     params:
       files/config.yaml:
@@ -77,6 +79,6 @@ stages:
     outs:
     - path: .output/communicate/
       hash: md5
-      md5: 6a7fb15dd1e9ad152dca372f663aefed.dir
-      size: 19293634
+      md5: 729822a64dcdcf57b5810cf060701f54.dir
+      size: 19310684
       nfiles: 19

--- a/examples/cybench/files/config.yaml
+++ b/examples/cybench/files/config.yaml
@@ -4,12 +4,12 @@ model:
       mapping_name:
         Success Count: n_correct
         Total Attempts: n_total
-        Sample ID: task_id
+        Sample ID: task
     ModelBinomial:
       mapping_name:
         Success Count: n_correct
         Total Attempts: n_total
-        Sample ID: task_id
+        Sample ID: task
 platform:
 checkers:
   checks:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
As the model can be fed data from multiple sources, the column name data mapping should remain in the config.yaml. 

e.g. I got this error on running

```
INFO:2025-05-02 11:07:07,905:jax._src.xla_bridge:867: Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/home/ubuntu/hibayes/.venv/bin/hibayes-model", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/ubuntu/hibayes/src/hibayes/cli/model.py", line 59, in main
    run_model(args)
  File "/home/ubuntu/hibayes/src/hibayes/cli/model.py", line 29, in run_model
    analysis_state = model(
                     ^^^^^^
  File "/home/ubuntu/hibayes/src/hibayes/analysis.py", line 106, in model
    for model_analysis_state in model_config.build_models(data):
  File "/home/ubuntu/hibayes/src/hibayes/model/model.py", line 198, in build_models
    features, coords = model_builder.prepare_data(data)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/hibayes/src/hibayes/model/models/models.py", line 347, in prepare_data
    features, coords = self._prepare_data(data_copy)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/hibayes/src/hibayes/model/models/models.py", line 542, in _prepare_data
    data = data.groupby(['model', 'task']).agg({'score':['count', 'sum']}).reset_index() # get nb total scores and nb correct scores
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/hibayes/.venv/lib/python3.12/site-packages/pandas/core/frame.py", line 9183, in groupby
    return DataFrameGroupBy(
           ^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/hibayes/.venv/lib/python3.12/site-packages/pandas/core/groupby/groupby.py", line 1329, in __init__
    grouper, exclusions, obj = get_grouper(
                               ^^^^^^^^^^^^
  File "/home/ubuntu/hibayes/.venv/lib/python3.12/site-packages/pandas/core/groupby/grouper.py", line 1043, in get_grouper
    raise KeyError(gpr)
KeyError: 'task'
```
### What is the new behavior?
-mapping of column names stays in the config
- removed the need for '_' removal after the agg step
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Could you try this out Magda on your non agg data or point me to the s3 loc?
### Other information:
