### PR TITLE
#33 only rename cols if mapping_name provided

### DIFF
--- a/src/hibayes/model/models/models.py
+++ b/src/hibayes/model/models/models.py
@@ -599,8 +599,6 @@ class ModelBetaBinomial(BaseModel):
             "success_prob",
         ]
 
-        config.mapping_name = {}
-
         return config
 
     def build_model(self) -> Callable[..., Any]:
@@ -739,8 +737,6 @@ class ModelBinomial(BaseModel):
             "overall_mean",
             "success_prob",
         ]
-
-        config.mapping_name = {}
 
         return config
 

--- a/src/hibayes/model/models/models.py
+++ b/src/hibayes/model/models/models.py
@@ -344,7 +344,11 @@ class BaseModel(ABC):
         Prepare data for modeling. Wraps the abstract method _prepare_data so
         to enforce that observed variable in features.
         """
-        data_copy = data.rename(columns=self.config.mapping_name)
+        data_copy = (
+            data.rename(columns=self.config.mapping_name)
+            if self.config.mapping_name
+            else data.copy()
+        )
         features, coords = self._prepare_data(data_copy)
 
         if "obs" not in features:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When no index + an empty dict is passed to cols rename, this throws and error.
### What is the new behavior?
Only call rename if mapping is not empty.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
