### PR TITLE
reverting the imports that ruff removed due to not being included in …

### DIFF
--- a/src/hibayes/analyse/__init__.py
+++ b/src/hibayes/analyse/__init__.py
@@ -1,6 +1,17 @@
 from ._check import Checker, CheckerResult, checker
 from .checker_config import CheckerConfig
-from .checkers import prior_predictive_check, prior_predictive_plot
+from .checkers import (
+    bfmi,
+    divergences,
+    ess_bulk,
+    ess_tail,
+    loo,
+    posterior_predictive_plot,
+    prior_predictive_check,
+    prior_predictive_plot,
+    r_hat,
+    waic,
+)
 
 __all__ = [
     "prior_predictive_check",
@@ -9,4 +20,12 @@ __all__ = [
     "Checker",
     "checker",
     "CheckerResult",
+    "bfmi",
+    "divergences",
+    "ess_bulk",
+    "ess_tail",
+    "loo",
+    "posterior_predictive_plot",
+    "r_hat",
+    "waic",
 ]

--- a/src/hibayes/communicate/__init__.py
+++ b/src/hibayes/communicate/__init__.py
@@ -1,9 +1,19 @@
 from ._communicate import CommunicateResult, Communicator, communicate
 from .communicate_config import CommunicateConfig
+from .plots import (
+    forest_plot,
+    model_comparison_plot,
+    pair_plot,
+    trace_plot,
+)
 
 __all__ = [
     "Communicator",
     "CommunicateResult",
     "communicate",
     "CommunicateConfig",
+    "forest_plot",
+    "model_comparison_plot",
+    "pair_plot",
+    "trace_plot",
 ]

--- a/src/hibayes/load/__init__.py
+++ b/src/hibayes/load/__init__.py
@@ -1,10 +1,11 @@
 from .configs.config import DataLoaderConfig
 from .extractors import MetadataExtractor
-from .load import LogProcessor
+from .load import LogProcessor, get_sample_df
 
 __all__ = [
     "LogProcessor",
     "get_sample_df_efficient",
     "DataLoaderConfig",
     "MetadataExtractor",
+    "get_sample_df",
 ]


### PR DESCRIPTION
…__all__

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
hibayes-full errors out as ruff removed key imports from __init__.pys 
### What is the new behavior?
Adding key functions to __all__ so ruff does not remove.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
