### PR TITLE
do not store the devices, calculate on the fly + Predictive should n…

### DIFF
--- a/src/hibayes/check/checkers.py
+++ b/src/hibayes/check/checkers.py
@@ -373,7 +373,7 @@ def posterior_predictive_plot(
                 state.model,
                 posterior_samples=_posterior_samples_as_dict(state.inference_data),
                 num_samples=num_samples,
-                parallel=state.platform_config.chain_method != "sequential",
+                parallel=False,  # vectorised in mcmc actually samples sequentially as each sample is dependent on the previous one. In Predictive, this is not the case. This can introduce significnat memory requirements. Disabling now to avoid OOM errors.
                 **predictive_kwargs,
             )
             pp_samples = predictive(

--- a/src/hibayes/platform/config.py
+++ b/src/hibayes/platform/config.py
@@ -17,7 +17,6 @@ ChainMethod = Literal["parallel", "sequential", "vectorized"]
 class PlatformConfig:
     device_type: str = "cpu"  # Device type (cpu, gpu, tpu)
     num_devices: int | None = None  # Number of devices to use (None = auto-detect)
-    devices: list[str] | None = None  # List of device names (e.g., ["gpu:0", "gpu:1"])
     gpu_memory_fraction: float = 0.9  # Fraction of GPU memory to use (0.1-1.0)
     chain_method: ChainMethod = "parallel"  # Method for running chains
 
@@ -35,7 +34,6 @@ class PlatformConfig:
                 try:
                     gpu_devices = jax.devices("gpu")
                     self.num_devices = len(gpu_devices) if gpu_devices else 0
-                    self.devices = gpu_devices if gpu_devices else []
                     if self.num_devices == 0:
                         raise RuntimeError("No GPU devices found")
                 except Exception:
@@ -86,6 +84,5 @@ class PlatformConfig:
             device_type=config.get("device_type", "cpu"),
             num_devices=config.get("num_devices", None),
             gpu_memory_fraction=config.get("gpu_memory_fraction", 0.9),
-            devices=config.get("devices", None),
             chain_method=config.get("chain_method", "parallel"),
         )

--- a/src/hibayes/platform/setup.py
+++ b/src/hibayes/platform/setup.py
@@ -48,14 +48,12 @@ def configure_computation_platform(
 
             _configure_gpu_memory(platform_config, display)
 
-            display.update_logs(
-                f"Using {len(platform_config.devices)} GPU(s) for computation"
-            )
+            display.update_logs(f"Using {len(jax.devices())} GPU(s) for computation")
 
             # For multi-GPU setups, JAX automatically distributes computation
             # across all available GPUs. For single GPU, we can set it as default
-            if len(platform_config.devices) == 1:
-                jax.config.update("jax_default_device", platform_config.devices[0])
+            if len(jax.devices()) == 1:
+                jax.config.update("jax_default_device", jax.devices()[0])
                 display.update_logs("Single GPU setup - set as default device")
             else:
                 display.update_logs(


### PR DESCRIPTION
…ot use vmap as tries to sample all 500 samples at once -> OOM without crazy high GPU mem

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
- Chain method was not being passed from user config.
- Predictive would occasionally fail due to OOM despite MCMC being fine. This is due to MCMC sampling sequential (even in vectorised) and Predictive sampling everything at once (as posteriors not being updated). Fixed Predictive to have parrallel to False to avoid confusion (+ this process is quite fast anyway).


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
