### PR TITLE
avoid os error when plots and tables contains lots of parameters

### DIFF
--- a/src/hibayes/analysis_state.py
+++ b/src/hibayes/analysis_state.py
@@ -443,6 +443,13 @@ class AnalysisState:
 
     def add_plot(self, plot: plt.Figure, plot_name: str) -> None:
         """Add a plot to the communicate."""
+
+        # limit max len of plot_name
+        if len(plot_name) > 100:
+            plot_name = plot_name[:100]
+            logger.warning(
+                f"Plot name too long, truncated to 100 characters: {plot_name}"
+            )
         if self._communicate is None:
             self._communicate = {}
         unique_name = self._get_unique_name(plot_name)
@@ -450,6 +457,11 @@ class AnalysisState:
 
     def add_table(self, table: pd.DataFrame, table_name: str) -> None:
         """Add a table to the communicate."""
+        if len(table_name) > 100:
+            table_name = table_name[:100]
+            logger.warning(
+                f"Table name too long, truncated to 100 characters: {table_name}"
+            )
         if self._communicate is None:
             self._communicate = {}
         unique_name = self._get_unique_name(table_name)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
If you have more than ~ 10 parameters in your plot/table the number of chars in the file name throws an OS error.
### What is the new behavior?
File names are concatenated if exceed 100 chars
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
