### PR TITLE
Add docstrings for model checkers

### DIFF
--- a/src/hibayes/check/checkers.py
+++ b/src/hibayes/check/checkers.py
@@ -401,6 +401,9 @@ def loo(reff_threshold: float = 0.7):
     High Pareto k values indicate observations that are difficult to predict and
     where the importance sampling approximation may be unreliable.
 
+    Based on Vehtari, Gelman & Gabry (2017):
+    https://arxiv.org/abs/1507.04544
+
     Args:
         reff_threshold: Maximum acceptable Pareto k value. Default is 0.7.
 
@@ -629,6 +632,9 @@ def waic(scale: str = "log") -> Checker:
     WAIC estimates out-of-sample predictive accuracy using the log pointwise
     predictive density. It provides similar information to LOO-PSIS but uses
     a different approximation method.
+
+    Based on Vehtari, Gelman & Gabry (2017):
+    https://arxiv.org/abs/1507.04544
 
     Args:
         scale: Output scale for WAIC; one of "deviance" or "log" (default).


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The documentation for the model checkers doesn't make it obvious what they are computing or what they are used for

### What is the new behavior?

Adds docstrings for all checkers, and specifies whether checkers are MCMC diagnostics, Hamiltonian MCMC specific diagnostics, or for model comparison

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
